### PR TITLE
Ajout d’animations et harmonisation CSS (issue #140)

### DIFF
--- a/cis/app/frontend/scripts/components/CISProjectCard.vue
+++ b/cis/app/frontend/scripts/components/CISProjectCard.vue
@@ -75,6 +75,10 @@ export default {
 	box-shadow : $cis-discrete-shadow;
 }
 
+.proj-card:hover {
+	box-shadow : $cis-strong-shadow;
+}
+
 .proj-card-img {
 	border-radius : 3px 3px 0px 0px ;
 }

--- a/cis/app/frontend/scripts/components/screens/CISProjectScreen.vue
+++ b/cis/app/frontend/scripts/components/screens/CISProjectScreen.vue
@@ -30,7 +30,7 @@
                                 <p>{{project.projectPartners}}</p>
                             </div>
 
-                            <a v-if="project.website" :href="project.website" target="_blank">Voir le site du projet</a>
+                            <a v-if="project.website" :href="project.website" class="link-primary" target="_blank">Voir le site du projet</a>
                         </div>
                     </div>
 
@@ -170,11 +170,6 @@ a.back{
 
     p{
         margin-bottom: 1em;
-    }
-    
-    a{
-        color: $cis-primary;
-        border-bottom: 1px solid $cis-primary;
     }
 } 
 

--- a/cis/app/frontend/styles/cis-misc.scss
+++ b/cis/app/frontend/styles/cis-misc.scss
@@ -6,3 +6,4 @@ $cis-search-bar-height: rem(65px);
 $cis-navbar-font-size: rem(16px);
 
 $cis-discrete-shadow: 0 3px 6px #D6D6D6;
+$cis-strong-shadow: 0 6px 12px #AAA;

--- a/cis/app/frontend/styles/commons.scss
+++ b/cis/app/frontend/styles/commons.scss
@@ -51,42 +51,49 @@ p a.colored {
 			border-right: 1px solid $cis-grey-light;
 		}
 		
-		// Animation: bar unter the text, filling itself when hovered
-		&:not(.selected) a{
-			color: inherit;
-			position: relative;
-			text-decoration: none;
-			padding-bottom: 0.3em;
-			&:hover{
-				color: inherit;
-			}
-			&:before{
-				content: "";
-				position: absolute;
-				width: 100%;
-				height: 1px;
-				bottom: 0;
-				left: 0;
-				background-color: $cis-primary;
-				visibility: hidden;
-				-webkit-transform: scaleX(0);
-				-webkit-transform-origin: left center;
-				transform: scaleX(0);
-				transform-origin: left center;
-				-webkit-transition: all 0.3s linear 0s;
-				transition: all 0.3s linear 0s;
-			}
-			&:hover:before{
-				visibility: visible;
-				-webkit-transform: scaleX(1);
-				transform: scaleX(1);
-			}
+		&.disabled{
+			color: $cis-grey-light;
 		}
-	}	
+	}
+}
+
+// Animation: bar unter the text, filling itself when hovere
+.navbar-item:not(.selected):not(.disabled) a:not(.selected):not(.disabled), 
+.cis-tabs li:not(.selected):not(.disabled) a{
+	color: inherit;
+	position: relative;
+	text-decoration: none;
+	padding-bottom: 0.4em;
+	&:hover{
+		color: inherit;
+	}
+	&:before{
+		content: "";
+		position: absolute;
+		width: 100%;
+		height: 1px;
+		bottom: 0;
+		left: 0;
+		background-color: $cis-primary;
+		visibility: hidden;
+		-webkit-transform: scaleX(0);
+		-webkit-transform-origin: left center;
+		transform: scaleX(0);
+		transform-origin: left center;
+		-webkit-transition: all 0.3s linear 0s;
+		transition: all 0.3s linear 0s;
+	}
+	&:hover:before{
+		visibility: visible;
+		-webkit-transform: scaleX(1);
+		transform: scaleX(1);
+	}
 }
 
 #navbar-main .navbar-item.selected a,
-.cis-tabs li.selected a{
+.cis-tabs li.selected a,
+html[lang="fr"] nav #navbar-main .navbar-item [lang="fr"],
+html[lang="en"] nav #navbar-main .navbar-item [lang="en"] {
 	font-weight: bold;
 	padding-bottom: 0.3em;
 	border-bottom: 1px solid $cis-primary;

--- a/cis/app/frontend/styles/commons.scss
+++ b/cis/app/frontend/styles/commons.scss
@@ -39,9 +39,10 @@ p a.colored {
 	padding-top: $cis-spacing_4;
 	margin-bottom: $cis-spacing_3;
 
+
 	li{
 		padding: 0 2em;
-
+		transition: .3s;
 		&:first-child{
 			padding-left: 0;
 		}
@@ -50,8 +51,36 @@ p a.colored {
 			border-right: 1px solid $cis-grey-light;
 		}
 		
-		a{
+		// Animation: bar unter the text, filling itself when hovered
+		&:not(.selected) a{
 			color: inherit;
+			position: relative;
+			text-decoration: none;
+			padding-bottom: 0.3em;
+			&:hover{
+				color: inherit;
+			}
+			&:before{
+				content: "";
+				position: absolute;
+				width: 100%;
+				height: 1px;
+				bottom: 0;
+				left: 0;
+				background-color: $cis-primary;
+				visibility: hidden;
+				-webkit-transform: scaleX(0);
+				-webkit-transform-origin: left center;
+				transform: scaleX(0);
+				transform-origin: left center;
+				-webkit-transition: all 0.3s linear 0s;
+				transition: all 0.3s linear 0s;
+			}
+			&:hover:before{
+				visibility: visible;
+				-webkit-transform: scaleX(1);
+				transform: scaleX(1);
+			}
 		}
 	}	
 }

--- a/cis/app/frontend/styles/commons.scss
+++ b/cis/app/frontend/styles/commons.scss
@@ -30,6 +30,37 @@ p a.colored {
 	color: $cis-primary;
 	text-decoration: underline;
 }
+a.link-primary, a.link-on-primary {
+	display: inline-block;
+	margin-top: 1em;
+	text-indent: 0.2em;
+	padding-right: 0.2em;
+}
+
+a.link-primary {
+	color: $cis-primary;
+	border-bottom: 1px solid currentColor;
+	&:hover {
+		color:$cis-primary-invert;
+		background-color:$cis-primary;
+	}
+}
+a.link-on-primary {
+	color: $cis-primary-invert;
+	border-bottom: 1px solid currentColor;
+	&:hover {
+		color:$cis-primary;
+		background-color:$cis-primary-invert;
+	}
+}
+a.inline {
+	display: inline;
+}
+
+.disabled {
+	opacity: $disabled-opacity; 
+	pointer-events: none;
+}
 
 .cis-tabs{
 	display: flex;
@@ -58,8 +89,8 @@ p a.colored {
 }
 
 // Animation: bar unter the text, filling itself when hovere
-.navbar-item:not(.selected):not(.disabled) a:not(.selected):not(.disabled), 
-.cis-tabs li:not(.selected):not(.disabled) a{
+.navbar-item:not(.selected) a:not(.selected), 
+.cis-tabs li:not(.selected) a{
 	color: inherit;
 	position: relative;
 	text-decoration: none;
@@ -154,11 +185,6 @@ footer h2{
 	font-weight: bold;
 	font-size: 1.1em;
 	margin-bottom: 0.5em;
-}
-
-footer h2 a {
-	color: currentColor;
-	text-decoration: underline;
 }
 
 footer .column h2:not(:first-of-type){

--- a/cis/app/frontend/styles/custom-bulma.scss
+++ b/cis/app/frontend/styles/custom-bulma.scss
@@ -26,6 +26,7 @@ $link-hover 	: $cis-primary;
 $family-sans-serif 	: "Barlow", sans-serif ;
 $family-primary 	: $family-sans-serif ; 
 
+$button-disabled-opacity: 0.7 ;
 
 // Import the rest of Bulma at the end
 @import "../node_modules/bulma/bulma.sass";
@@ -42,3 +43,19 @@ form .control{
 .is-checkradio[type="checkbox"] + label{
     font-size: $cis-navbar-font-size
 }
+
+// Bulma default behaviour darkens the button, doesn't fit for CIS
+.button.is-primary:hover{
+    background-color:$primary-invert;
+    color:$primary;
+    border-color:$primary;
+}
+// Bulma default has a transparent background, causing the button
+// to become invisible on a purple background
+.button.is-primary.is-outlined{
+    background-color:$primary-invert;
+}
+.button.is-primary.is-outlined:hover{
+    border-color:$primary-invert;
+}
+

--- a/cis/app/frontend/styles/custom-bulma.scss
+++ b/cis/app/frontend/styles/custom-bulma.scss
@@ -26,7 +26,8 @@ $link-hover 	: $cis-primary;
 $family-sans-serif 	: "Barlow", sans-serif ;
 $family-primary 	: $family-sans-serif ; 
 
-$button-disabled-opacity: 0.7 ;
+$disabled-opacity: 0.7 ;
+$button-disabled-opacity: $disabled-opacity ;
 
 // Import the rest of Bulma at the end
 @import "../node_modules/bulma/bulma.sass";

--- a/cis/app/frontend/styles/home.scss
+++ b/cis/app/frontend/styles/home.scss
@@ -159,11 +159,6 @@ main#home{
         h2{
             color: $cis-primary;
             text-align: left;
-
-            a{
-                color: inherit;
-                text-decoration: underline;
-            }
         }
     
         .rejoindre{

--- a/cis/app/frontend/styles/home.scss
+++ b/cis/app/frontend/styles/home.scss
@@ -102,10 +102,6 @@ main#home{
                 justify-content: center;
                 
                 button{
-                    color: $cis-primary-invert;
-                    background-color: $cis-primary;
-        
-                    font-size: rem(18px);
                     height: rem(50px);
                 }
             }
@@ -174,11 +170,9 @@ main#home{
             align-items: center;
             color: $cis-primary;
 
-            a{
-                color: $cis-primary-invert;
-                background-color: $cis-primary;
-                margin-top: 1em;
-            }
+	    a{
+		margin-top: 1em;
+	    }
         }
     }
 
@@ -226,9 +220,6 @@ main#home{
 
         a.button{
             margin-bottom: 1.5em;
-            
-            color: $cis-primary;
-            border-color: $cis-primary;
         }
     } 
 

--- a/cis/app/frontend/styles/http-errors.scss
+++ b/cis/app/frontend/styles/http-errors.scss
@@ -26,10 +26,6 @@
         padding-bottom: 1rem;
     }
 
-    a.button.is-primary.is-outlined{
-        background-color: white;
-    }
-    
     &.no-result{
         height: 70vh;
     }

--- a/cis/app/frontend/styles/le-collectif.scss
+++ b/cis/app/frontend/styles/le-collectif.scss
@@ -88,9 +88,6 @@ main#le-collectif{
         .button{
             height: unset;
             padding: 1em 2em;
-            color: $cis-primary;
-    
-            border: 1px solid $cis-primary;
         }
     
         .rejoindre{

--- a/cis/app/frontend/styles/le-collectif.scss
+++ b/cis/app/frontend/styles/le-collectif.scss
@@ -32,12 +32,8 @@ main#le-collectif{
                 }
 
                 a{
-                    color: $cis-primary;
                     font-weight: normal;
-            
                     white-space: nowrap;
-            
-                    border-bottom: 1px solid $cis-primary;
                 }
             }
         

--- a/cis/app/frontend/styles/le-projet.scss
+++ b/cis/app/frontend/styles/le-projet.scss
@@ -172,12 +172,6 @@ main#projet{
             p {
                 padding-bottom: 2em;
             }
-        
-            a {
-                color: $cis-primary;
-                border: 1px solid $cis-primary;
-                background-color: $cis-primary-invert;
-            }
         }
     }
 
@@ -204,7 +198,7 @@ main#projet{
                 display: inline-block;
                 margin-top: 1em;
         
-                color: white;
+        	color: white;
                 border-bottom: 1px solid currentColor;
             }
         }

--- a/cis/app/frontend/styles/le-projet.scss
+++ b/cis/app/frontend/styles/le-projet.scss
@@ -194,13 +194,6 @@ main#projet{
                 color: inherit;
             }
         
-            a{
-                display: inline-block;
-                margin-top: 1em;
-        
-        	color: white;
-                border-bottom: 1px solid currentColor;
-            }
         }
     }
 }

--- a/cis/app/frontend/styles/navbar.scss
+++ b/cis/app/frontend/styles/navbar.scss
@@ -2,17 +2,9 @@
 @import './cis-colors.scss';
 @import './cis-misc.scss';
 
-html[lang="fr"] nav #navbar-main .navbar-item [lang="fr"],
-html[lang="en"] nav #navbar-main .navbar-item [lang="en"]{
-	text-decoration: underline;
-}
 
 nav{
 	font-size: $cis-navbar-font-size;
-}
-
-#navbar-main .navbar-item.selected a{
-	transform: translateY(0.2em);
 }
 
 #navbar-main .navbar-item{
@@ -21,6 +13,7 @@ nav{
 
 	a{
 		color: $cis-text-color;
+		padding-bottom: 0.3em;
 	}
 }
 

--- a/cis/app/frontend/styles/outils.scss
+++ b/cis/app/frontend/styles/outils.scss
@@ -116,10 +116,5 @@ main#outils{
             background-color: $cis-primary;
             border: 1px solid $cis-primary;
         }
-        a.github{
-            color: $cis-primary;
-            background-color: $cis-primary-invert;
-            border: 1px solid $cis-primary;
-        }
     }
 }

--- a/cis/app/frontend/styles/parlent-de-nous.scss
+++ b/cis/app/frontend/styles/parlent-de-nous.scss
@@ -49,13 +49,6 @@ section#presse {
                 }
             }
         
-            a{
-                color: $cis-primary;
-                border-bottom: 1px solid currentColor;
-        
-                display: inline-block;
-                padding: 0.5em 0;
-            }
         }
     }
     

--- a/cis/app/templates/footer.html
+++ b/cis/app/templates/footer.html
@@ -27,7 +27,7 @@
 				{% include "elements/newsletter-mailchimp.html" %}
 
 				{# contact us #}
-				<h2 class="has-text-primary"><a href="/contact">Contactez-nous</a></h2>
+				<h2 class="has-text-primary"><a class="link-primary" href="/contact">Contactez-nous</a></h2>
 
 				{# social networks #}
 				<h2 class="has-text-primary">Suivez-nous</h2>

--- a/cis/app/templates/le-collectif.html
+++ b/cis/app/templates/le-collectif.html
@@ -19,7 +19,7 @@
 
                 <h2 class="title is-4">Le collectif, comment ça marche ?</h2>
                 <ul>
-                    <li>Il réunit tous les membres adhérant à la charte <a target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Téléchargez la charte</a>
+                    <li>Il réunit tous les membres adhérant à la charte <a class="link-primary" target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Téléchargez la charte</a>
                     <li>Il se réunit deux fois par an
                     <li>Il fixe les orientations et décisions stratégiques
                 </ul>

--- a/cis/app/templates/le-collectif.html
+++ b/cis/app/templates/le-collectif.html
@@ -41,7 +41,7 @@
 
         <div class="columns">
             <div class="column is-offset-1 is-3">
-                <a class="button"
+                <a class="button is-primary is-outlined"
                     href="/qui-sommes-nous/qui-fait-quoi"
                 >
                 Découvrez le portrait des membres
@@ -54,7 +54,7 @@
                 <div class="rejoindre">
                     <h2 class="title is-2">Vous êtes une structure de l’innovation sociale et vous voulez participer au projet ?</h2>
                     
-                    <a class="button" href="/nous-rejoindre">Rejoignez le collectif</a>
+                    <a class="button is-primary is-outlined" href="/nous-rejoindre">Rejoignez le collectif</a>
                 </div>
             </div>
         </div>

--- a/cis/app/templates/le-projet-english.html
+++ b/cis/app/templates/le-projet-english.html
@@ -89,17 +89,17 @@
                 <img src="/static/illustrations/Projet_moteur_de_recherche.png">
                 <h1>A search engine</h1>
                 <p>To better discover, identify and localize social innovation projects in France</p>
-                <a href="/recherche">Begin a search</a>
+                <a class="button is-primary is-outlined" href="/recherche">Begin a search</a>
             <li>
                 <img src="/static/illustrations/Projet_collectif.png">
                 <h1>A community</h1>
                 <p>We create a privileged space to get to know and discuss with those who coach, finance and develop social innovations in France.</p>
-                <a href="/qui-sommes-nous">Discover the members of our community</a>
+                <a class="button is-primary is-outlined" href="/qui-sommes-nous">Discover the members of our community</a>
             <li>
                 <img src="/static/illustrations/Projet_logiciels_libres.png">
                 <h1>Open source softwares</h1>
                 <p>We have invested in the conception and development of custom-made applications to scrap, aggregate, consolidate and visualize heterogeneous data.</p>
-                <a href="/le-projet/outils">Discover our toolbox</a>
+                <a class="button is-primary is-outlined" href="/the-project/tools">Discover our toolbox</a>
         </div>
     </section>
 

--- a/cis/app/templates/le-projet-english.html
+++ b/cis/app/templates/le-projet-english.html
@@ -114,7 +114,7 @@
             <div class="charte column is-3 is-offset-2">
                 <h1>The community Charter</h1>
                 <p>The Charter presents the principles, objectives and organisation of Social Innovations Crossroad’s community.</p>
-                <a target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Download the Charter</a>
+                <a class="link-on-primary" target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Download the Charter</a>
             </div>
         </div>
     </section>

--- a/cis/app/templates/le-projet.html
+++ b/cis/app/templates/le-projet.html
@@ -102,21 +102,21 @@
                     <img src="/static/illustrations/Projet_moteur_de_recherche.png">
                     <h2 class="title is-2">Un moteur de recherche</h2>
                     <p>Pour mieux découvrir, repérer et localiser les projets d’innovation sociales en France.</p>
-                    <a class="button" href="/recherche">Commencer une recherche</a>
+                    <a class="button is-primary is-outlined" href="/recherche">Commencer une recherche</a>
                 </div>
             <li class="column is-third">
                 <div class="cis-card">
                     <img src="/static/illustrations/Projet_collectif.png">
                     <h2 class="title is-2">Un collectif</h2>
                     <p>Nous créons un espace privilégié pour connaître et échanger avec ceux qui accompagnent, financent et développent les innovations sociales en France.</p>
-                    <a class="button" href="/qui-sommes-nous">Découvrez les membres du collectif</a>
+                    <a class="button is-primary is-outlined" href="/qui-sommes-nous">Découvrez les membres du collectif</a>
                 </div>
             <li class="column is-third">
                 <div class="cis-card">
                     <img src="/static/illustrations/Projet_logiciels_libres.png">
                     <h2 class="title is-2">Des logiciels libres</h2>
                     <p>Nous développons des logiciels spécialement pour le projet. Ils permettent de récupérer l’information sur les sites des partenaires, de la consolider et de la visualiser.</p>
-                    <a class="button" href="/le-projet/outils">Découvrez nos outils</a>
+                    <a class="button is-primary is-outlined" href="/le-projet/outils">Découvrez nos outils</a>
                 </div>
         </div>
     </section>

--- a/cis/app/templates/le-projet.html
+++ b/cis/app/templates/le-projet.html
@@ -132,7 +132,7 @@
             <div class="charte column is-3 is-offset-2">
                 <h1 class="title is-2">La charte du collectif</h1>
                 <p>Elle définit les objectifs, principes et modes d’organisation du Carrefour des innovations sociales.</p>
-                <a target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Téléchargez la charte</a>
+                <a class="link-on-primary" target="_blank" href="/static/files/Charte_carrefourdesinnovationssociales_VF_V2.pdf">Téléchargez la charte</a>
             </div>
         </div>
     </section>

--- a/cis/app/templates/les-outils-english.html
+++ b/cis/app/templates/les-outils-english.html
@@ -51,7 +51,7 @@
                 <li>Open data and control the degree of their sharing (from private data to open data)
             </ul>
             <!-- <a class="test" href="">Tester Open Scraper</a> -->
-            <a class="github" href="https://github.com/entrepreneur-interet-general/OpenScraper">Check on Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/OpenScraper">Check on Github</a>
         </div>
     </section>
 
@@ -71,7 +71,7 @@
                 <li>Open data and control the degree of their sharing (from private data to open data)
             </ul>
             <!-- <a class="test" href="">Tester Solidata</a> -->
-            <a class="github" href="https://github.com/entrepreneur-interet-general/solidata_frontend">Check on Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/solidata_frontend">Check on Github</a>
         </div>
     </section>
 
@@ -90,7 +90,7 @@
                 <li>Make its own favorite list
             </ul>
             <!-- <a class="test" href="">Tester Apiviz</a> -->
-            <a class="github" href="https://github.com/entrepreneur-interet-general/CIS-front">Check on Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/CIS-front">Check on Github</a>
         </div>
     </section>
 <!--

--- a/cis/app/templates/les-outils.html
+++ b/cis/app/templates/les-outils.html
@@ -55,7 +55,7 @@
                 <li>Ouvrir les données en maîtrisant leurs degrés d'ouverture (des données qui restent privées à de l’open data)
             </ul>
             <!-- <a class="test" href="">Tester Open Scraper</a> -->
-            <a class="github button" href="https://github.com/entrepreneur-interet-general/OpenScraper">Voir sur Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/OpenScraper">Voir sur Github</a>
         </div>
     </section>
 
@@ -76,7 +76,7 @@
                 <li>Ouvrir les données en maîtrisant leurs degrés d’ouverture (des données qui restent privées à de l’open data)
             </ul>
             <!-- <a class="test" href="">Tester Solidata</a> -->
-            <a class="github button" href="https://github.com/entrepreneur-interet-general/solidata_frontend">Voir sur Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/solidata_frontend">Voir sur Github</a>
         </div>
     </section>
 
@@ -95,7 +95,7 @@
                 <li>Faire sa propre liste de favoris
             </ul>
             <!-- <a class="test" href="">Tester Apiviz</a> -->
-            <a class="github button" href="https://github.com/entrepreneur-interet-general/CIS-front">Voir sur Github</a>
+            <a class="github button is-primary is-outlined" href="https://github.com/entrepreneur-interet-general/CIS-front">Voir sur Github</a>
         </div>
     </section>
 <!--

--- a/cis/app/templates/navbars/navbar-main-english.html
+++ b/cis/app/templates/navbars/navbar-main-english.html
@@ -42,7 +42,7 @@
 			</div>
 
 			<div class="navbar-item">
-				<a lang="fr" href="/">FR</a>&nbsp;/&nbsp;<span lang="en">EN</span>
+				<a href="/" lang="fr">FR</a><a href="" class="disabled">&nbsp;/&nbsp;</a><a class="selected" lang="en" href="/en">EN</a>
 			</div>
 
 		</div>

--- a/cis/app/templates/navbars/navbar-main.html
+++ b/cis/app/templates/navbars/navbar-main.html
@@ -42,7 +42,7 @@
 			</div>
 
 			<div class="navbar-item">
-				<span lang="fr">FR</span>&nbsp;/&nbsp;<a lang="en" href="/en">EN</a>
+				<a href="" class="selected" lang="fr">FR</a><a href="" class="disabled">&nbsp;/&nbsp;</a><a lang="en" href="/en">EN</a>
 			</div>
 
 		</div>

--- a/cis/app/templates/new-home-english.html
+++ b/cis/app/templates/new-home-english.html
@@ -19,7 +19,7 @@
                         </input>
                     </div>
                     <div class="column is-2 is-hidden-touch">
-                        <button class="button is-fullwidth" type="submit">Search</button>
+                        <button class="button is-fullwidth is-primary is-normal" type="submit">Search</button>
                     </div>
                     {# <div class="column is-2 is-hidden-desktop">
                         <button class="button is-fullwidth" type="submit">R</button>
@@ -79,7 +79,7 @@
                     <p>
                         You capitalize social innovation projects and you’d like to share them in the Social Innovation Crossroad?
                     </p>
-                    <a class="button" href="/nous-rejoindre">Discover how to join the project</a>
+                    <a class="button is-primary" href="/nous-rejoindre">Discover how to join the project</a>
                 </div>
             </div>
 
@@ -89,7 +89,7 @@
     <section id="collectif">
         <h2 class="title is-1">A community of more than 50 members</h2>
         <p>Social innovation crossroad federates public institutions, networks, foundations, associations, medias and research centers.</p>
-        <div class="columns">
+        <div class="columns is-centered">
             <div class="column" style="flex: 2;">
                 <h3>They the started the project...</h3>
                 <ul class="columns">
@@ -108,7 +108,9 @@
                 </ul>
             </div>
         </div>
-        <a class="button" href="./qui-sommes-nous">Discover all members of the community</a>
+        <div class="columns is-centered">
+        <a class="button is-primary is-outlined" href="./qui-sommes-nous">Discover all members of the community</a>
+        </div>
         <div>
             <h3>They support the project</h3>
             <ul class="columns">

--- a/cis/app/templates/new-home-english.html
+++ b/cis/app/templates/new-home-english.html
@@ -63,7 +63,7 @@
 
                     <h1 class="title is-1">How to participate?</h1>
                     <h2 class="title is-2">
-                        <strong>We don’t collect directly projects, we highlight those collected by members of our <a href="/qui-sommes-nous">community</a>.</strong>
+                        <strong>We don’t collect directly projects, we highlight those collected by members of our <a class="link-primary inline" href="/qui-sommes-nous">community</a>.</strong>
                     </h2>
                     <p>
                         Hundreds of websites already collect social innovation projects. We want this information to be more accessible. Community members’ websites are automatically scraped, they don’t have to fill again all the information. Every actor already highlighting social innovations can join the community.

--- a/cis/app/templates/new-home.html
+++ b/cis/app/templates/new-home.html
@@ -20,7 +20,7 @@
                         </input>
                     </div>
                     <div class="column is-2 is-hidden-touch">
-                        <button class="button is-fullwidth" type="submit">Rechercher</button>
+                        <button class="button is-primary is-fullwidth is-normal" type="submit">Rechercher</button>
                     </div>
                     {# <div class="column is-2 is-hidden-desktop">
                         <button class="button is-fullwidth" type="submit">R</button>
@@ -83,7 +83,7 @@
                     <p>
                         Vous recensez des projets d’innovation sociale et vous souhaiteriez les partager&nbsp;? Ou vous êtes simplement intéréssé.e par notre démarche&nbsp;?
                     </p>
-                    <a class="button" href="/nous-rejoindre">Découvrez comment rejoindre le projet</a>
+                    <a class="button is-primary" href="/nous-rejoindre">Découvrez comment rejoindre le projet</a>
                 </div>
             </div>
 
@@ -96,7 +96,7 @@
             <div class="column is-10">
                 <h1 class="title is-1">Un collectif de plus de 50 membres</h1>
                 <p>
-                    Le Carrefour des innovations sociales rassemble des associations, têtes de réseaux, collectivités, fondations, médias, centres de recherche et institutions
+                    Le Carrefour des innovations sociales rassemble des associations, têtes de réseaux, collectivités, fondations, médias, centres de recherche et institutions.
                 </p>
                 <div class="columns is-centered">
                     <div class="column is-3">
@@ -118,7 +118,7 @@
                     </div>
                 </div>
                 <div class="columns is-centered">
-                    <a class="button" href="./qui-sommes-nous">Découvrez tous les membres du collectif</a>
+                    <a class="button is-primary is-outlined" href="./qui-sommes-nous">Découvrez tous les membres du collectif</a>
                 </div>
                 <br>
                 <div>

--- a/cis/app/templates/new-home.html
+++ b/cis/app/templates/new-home.html
@@ -66,7 +66,7 @@
                     <h1 class="title is-1">Comment participer ?</h1>
                     <h2 class="title is-2">
                         Nous ne référençons pas directement les projets. 
-                        <br>Nous relayons ceux recensés par les membres du <a href="/qui-sommes-nous">collectif</a>.
+                        <br>Nous relayons ceux recensés par les membres du <a class="link-primary inline" href="/qui-sommes-nous">collectif</a>.
                     </h2>
                     <p>
                         Des centaines de sites recensent déjà des projets d’innovation sociale. Nous voulons rendre cette information plus accessible. Les données sur les projets sont donc collectées auprès des sites des membres du collectif qui recensent des projets.

--- a/cis/app/templates/nous-rejoindre.html
+++ b/cis/app/templates/nous-rejoindre.html
@@ -27,7 +27,7 @@
     <section hidden class="project-carrier-expand container">
         <p>Le parti pris du Carrefour des innovations sociales est de rendre plus accessibles les projets déjà référencés sur les sites des membres du collectif.</p>
         <p>C’est pourquoi nous ne vous proposons pas directement un formulaire pour référencer votre projet. Pour en savoir plus, découvrez 
-            <a class="colored" href="/le-projet">l’histoire du projet</a>.
+            <a class="link-primary inline" href="/le-projet">l’histoire du projet</a>.
         </p>
 
         <br> 
@@ -53,7 +53,7 @@
 
         <section hidden class="not-yet-referenced-by-a-partner-expand">
             <p>Notre ambition est de valoriser tous les projets existants d’innovation sociale. Pour l’instant, nous réferençons sur le site seulement les projets suivis par les 
-                <a class="colored" href="/qui-sommes-nous/qui-fait-quoi">
+                <a class="link-primary inline" href="/qui-sommes-nous/qui-fait-quoi">
                 acteurs partenaires du collectif</a>.</p>
             <p>Cependant, nous vous invitons à remplir ce formulaire de mise en contact. Ces informations seront transmises aux membres du collectif qui pourront découvrir votre projet et prendre contact avec vous.</p>
             <br>

--- a/cis/app/templates/parlent-de-nous.html
+++ b/cis/app/templates/parlent-de-nous.html
@@ -24,7 +24,7 @@
                     <time datetime="2018-06-12">12 juin 2018</time>
                     <h1>NumeriquESS</h1>
                     <p>Carrefour des innovations sociales : connecter les initiatives de la société civile</p>
-                    <a href="https://numeriquess.squarespace.com/news/2018/4/3/9-carrefourdesinnovationssociales-3jep7-6g75-xg7mz-tep79-8h95x">Ecouter le podcast</a>
+                    <a class="link-primary" href="https://numeriquess.squarespace.com/news/2018/4/3/9-carrefourdesinnovationssociales-3jep7-6g75-xg7mz-tep79-8h95x">Ecouter le podcast</a>
                 </div>
                 
             <li>
@@ -35,7 +35,7 @@
                     <time datetime="2018-05-25">25 mai 2018</time>, par Sébastien Poulet-Goffard
                     <h1>Le Monde</h1>
                     <p>« Entrepreneurs et travailleurs sociaux, rencontrez-vous ! »</p>
-                    <a href="https://www.lemonde.fr/idees/article/2018/05/25/entrepreneurs-et-travailleurs-sociaux-rencontrez-vous_5304433_3232.html">Lire l’article</a>
+                    <a class="link-primary" href="https://www.lemonde.fr/idees/article/2018/05/25/entrepreneurs-et-travailleurs-sociaux-rencontrez-vous_5304433_3232.html">Lire l’article</a>
                 </div>
                 
             <li>
@@ -46,7 +46,7 @@
                     <time datetime="2018-05-28">28 mai 2018</time>
                     <h1>Podcast d’Actifs Radio</h1>
                     <p>Le Carrefour des Innovations Sociales veut contribuer à accélérer l’innovation sociale en France</p>
-                    <a href="http://www.actifsradio.fr/economie/398-carrefour-innovations-sociales">Ecouter le podcast</a>
+                    <a class="link-primary" href="http://www.actifsradio.fr/economie/398-carrefour-innovations-sociales">Ecouter le podcast</a>
                 </div>
                 
             <li>
@@ -57,7 +57,7 @@
                     <time datetime="2018-04-26">26 avril 2018</time>, par Caroline Megglé
                     <h1>Localtis, groupe Caisse des dépôts</h1>
                     <p>En bref - Le CGET et ses partenaires lancent leur Carrefour des innovations sociales</p>
-                    <a href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250280998219">Lire l’article</a>
+                    <a class="link-primary" href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250280998219">Lire l’article</a>
                 </div>
                 
             <li>
@@ -68,7 +68,7 @@
                     <time datetime="2018-04-18">18 avril 2018</time>, par Sylvain Maschino pour Fédération nationale des Caisses d'Epargne
                     <h1>Carenews</h1>
                     <p>Les Caisses d'Epargne s'engagent aux côtés du Carrefour des innovations sociales</p>
-                    <a href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250280998219">Lire l’article</a>
+                    <a class="link-primary" href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250280998219">Lire l’article</a>
                 </div>
                 
             <li>
@@ -79,7 +79,7 @@
                     <time datetime="2018-01-08">8 janvier 2018</time>, par Hélène Bustos
                     <h1>Transrural Initiatives</h1>
                     <p>Cartographier l’innovation sociale</p>
-                    <a href="http://www.transrural-initiatives.org/2017/03/transrural-initiatives-n465-decembre-2017/">Lire l’article</a>
+                    <a class="link-primary" href="http://www.transrural-initiatives.org/2017/03/transrural-initiatives-n465-decembre-2017/">Lire l’article</a>
                 </div>
                 
             <li>
@@ -90,7 +90,7 @@
                     <time datetime="2017-08-01">1 août 2017</time>
                     <h1>le laboratoire territorial</h1>
                     <p>Cartographier l’innovation sociale</p>
-                    <a href="https://www.labterritorial.fr/bientot-une-banque-de-linnovation-sociale/">Lire l’article</a>
+                    <a class="link-primary" href="https://www.labterritorial.fr/bientot-une-banque-de-linnovation-sociale/">Lire l’article</a>
                 </div>
                 
             <li>
@@ -101,7 +101,7 @@
                     <time datetime="2017-07-17">17 juillet 2017</time>, par Caroline Megglé
                     <h1>Localtis, groupe Caisse des dépôts</h1>
                     <p>Banque de l’innovation sociale : donner à voir une France des territoires extrêmement dynamique</p>
-                    <a href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250279556469">Lire l’article</a>
+                    <a class="link-primary" href="https://www.caissedesdepotsdesterritoires.fr/cs/ContentServer?pagename=Territoires/Articles/Articles&cid=1250279556469">Lire l’article</a>
                 </div>
                 
             <li>
@@ -112,7 +112,7 @@
                     <time datetime="2017-05">mai 2017</time>
                     <h1>La tribune Fonda</h1>
                     <p>Une plateforme web qui mettra en commun l’ensemble des innovations sociales recensées sur le territoire</p>
-                    <a href="https://fonda.asso.fr/ressources/le-carrefour-des-innovations-sociales">Lire l’article</a>
+                    <a class="link-primary" href="https://fonda.asso.fr/ressources/le-carrefour-des-innovations-sociales">Lire l’article</a>
                 </div>
                 
             <li>
@@ -123,7 +123,7 @@
                     <time datetime="2017-04-20">20 avril 2017</time>
                     <h1>Commissariat général à l’égalité des territoires</h1>
                     <p>Une banque de l’innovation sociale au service de l’expérimentation dans les territoires</p>
-                    <a href="http://www.cget.gouv.fr/une-banque-de-linnovation-sociale-service-de-lexperimentation-territoires">Lire l’article</a>
+                    <a class="link-primary" href="http://www.cget.gouv.fr/une-banque-de-linnovation-sociale-service-de-lexperimentation-territoires">Lire l’article</a>
                 </div>
 
         </ul>

--- a/cis/app/templates/recompenses-english.html
+++ b/cis/app/templates/recompenses-english.html
@@ -19,7 +19,7 @@
             <time>October 2018</time>
             <h1>Organisation for Economic Co-operation and Development (OECD)</h1>
             <p>We have been selected as one of the 2 French innovations by the OECD Observatory of Public Sector Innovation. Events and a report will help to present our works to an international audience..</p>
-            <a href="https://oecd-opsi.org/innovations/carrefour-des-innovations-sociales-social-innovation-crossroad/">Get to know the OECD</a>
+            <a class="link-primary" href="https://oecd-opsi.org/innovations/carrefour-des-innovations-sociales-social-innovation-crossroad/">Get to know the OECD</a>
         </div>
     </section>
 

--- a/cis/app/templates/recompenses.html
+++ b/cis/app/templates/recompenses.html
@@ -19,7 +19,7 @@
             <time>Octobre 2018</time>
             <h1 class="title is-2">Organisation de coopération et de développement économiques</h1>
             <p>Nous avons été retenus comme l’une des deux innovations françaises par l’Observatoire de l’innovation publique de l’OCDE. Un rapport publié par l’OCDE et des événements permettront de présenter nos travaux à un public international.</p>
-            <a href="https://oecd-opsi.org/innovations/carrefour-des-innovations-sociales-social-innovation-crossroad/">Connaître l’OECD</a>
+            <a class="link-primary" href="https://oecd-opsi.org/innovations/carrefour-des-innovations-sociales-social-innovation-crossroad/">Connaître l’OECD</a>
         </div>
     </section>
 


### PR DESCRIPTION
Ajout d’animations et harmonisation CSS (issue #140)

- effets de survol sur les boutons : à partir des classes Bulma `is-primary` et `is-outlined` (inversion des couleurs), surcharge partielle dans `custom-bulma.scss` pour éviter les boutons transparents donc potentiellement invisibles, par exemple
- effets de survol sur les liens : 
    - classe `inline` pour gérer les liens insérés dans du texte, 
    - `link-primary` pour les liens violets sur fonds blancs ou gris (deviennent blanc sur fond violet au survol)
     - `link-on-primary` pour les liens blancs sur fond violet (deviennent violet sur fond blanc au survol)
-> une autre solution serait de suivre la logique des classes Bulma pour les boutons pour ces liens : avec une classe `is-primary` pour les liens violets, et la combinaison `is-primary is-outlined` pour les liens blancs "inversés" ?
- animation du soulignage au `hover` sur les éléments de tabs (`cis-tabs` des pages et navbar) + harmonisation des options "FR/EN"
- "désactivation" des éléments via une classe `disabled` (transparence à 70% + interactions désactivées), le tag HTML `disabled` existe mais n’est pas disponible pour tous les types d’éléments
- renforcement de l’ombrage au survol des cartes projets
- nettoyage des fichiers CSS et HTML (templates Jinja) pour mettre en place les effets et enlever des bouts de style obsolètes
- testé avec Firefox 65 et Chromium 71 (Ubuntu)

Ping @JulienParis pour la review